### PR TITLE
ui.py: Declare instance variable

### DIFF
--- a/plugin/ui.py
+++ b/plugin/ui.py
@@ -167,6 +167,9 @@ TXT = [0x32, 0x47]
 
 
 class HdmiTest(Screen, ConfigListScreen):
+
+	instance = None
+
 	skin = """
 	<screen name="HdmiTest" position="center,center" size="640,400" title="HdmiTest" >
 		<ePixmap name="red"    position="0,0"   zPosition="2" size="140,40" pixmap="skin_default/buttons/red.png" transparent="1" alphatest="on" />


### PR DESCRIPTION
To fix:

File "/usr/lib/enigma2/python/Screens/Screen.py", line 271, in createGUIScreen
    f()
  File "/usr/lib/enigma2/python/Plugins/Extensions/HdmiTest/ui.py", line 249, in layoutFinished
    assert not HdmiTest.instance, "only one HdmiCec instance is allowed!"
AttributeError: type object 'HdmiTest' has no attribute 'instance'